### PR TITLE
Allow crossbuild of x86_64 on arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Locally test package installation
         run: |
-          cp iraf-*64.pkg /tmp
-          sudo installer -pkg /tmp/iraf-*64.pkg -target / -verbose
+          cp iraf-*.pkg /tmp
+          sudo installer -pkg /tmp/iraf-*.pkg -target / -verbose
           /usr/local/lib/iraf/test/run_tests /usr/local/lib/iraf/test/noao.astutil.md
 
       - name: Copy file via ssh
@@ -49,4 +49,4 @@ jobs:
         run: |
           ssh-agent -a $SSH_AUTH_SOCK
           ssh-add -v - <<< "${{ secrets.SSH_KEY }}"
-          scp -o StrictHostKeyChecking=no iraf-*64.pkg iraf@olebole.net:dist/
+          scp -o StrictHostKeyChecking=no iraf-*.pkg iraf@olebole.net:dist/

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ PATH += :$(BINDIR)
 
 all: iraf-$(RELEASE)-$(MACARCH).pkg
 
-PKGS = iraf-core.pkg x11iraf.pkg ctio.pkg fitsutil.pkg mscred.pkg	\
+PKGS = core.pkg x11iraf.pkg ctio.pkg fitsutil.pkg mscred.pkg	\
        rvsao.pkg sptable.pkg st4gem.pkg xdimsum.pkg
 
-iraf-core.pkg:
+core.pkg:
 	mkdir -p $(BUILDDIR)/iraf
 	curl -L https://github.com/iraf-community/iraf/archive/refs/heads/main.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/iraf --strip-components=1
@@ -49,7 +49,7 @@ iraf-core.pkg:
 		 --version 2.17.1+ \
 	         $@
 
-x11iraf.pkg: iraf-core.pkg
+x11iraf.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/x11iraf
 	curl -L https://github.com/iraf-community/x11iraf/archive/refs/heads/main.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/x11iraf --strip-components=1
@@ -70,7 +70,7 @@ x11iraf.pkg: iraf-core.pkg
 		 --version 2.1+ \
 	         $@
 
-ctio.pkg: iraf-core.pkg
+ctio.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/ctio
 	curl -L https://github.com/iraf-community/iraf-ctio/archive/refs/heads/main.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/ctio --strip-components=1
@@ -89,7 +89,7 @@ ctio.pkg: iraf-core.pkg
 		 --version 0+2023-11-12 \
 	         $@
 
-fitsutil.pkg: iraf-core.pkg
+fitsutil.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/cfitsio
 	curl -L https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.4.0.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/cfitsio --strip-components=1
@@ -116,7 +116,7 @@ fitsutil.pkg: iraf-core.pkg
 		 --version 0+2024-02-04 \
 	         $@
 
-mscred.pkg: iraf-core.pkg
+mscred.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/mscred
 	curl -L https://github.com/iraf-community/iraf-mscred/archive/refs/heads/main.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/mscred --strip-components=1
@@ -134,7 +134,7 @@ mscred.pkg: iraf-core.pkg
 		 --version 0+2023-12-12 \
 	         $@
 
-rvsao.pkg: iraf-core.pkg
+rvsao.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/rvsao
 	curl -L http://tdc-www.harvard.edu/iraf/rvsao/rvsao-2.8.5.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/rvsao --strip-components=1
@@ -153,7 +153,7 @@ rvsao.pkg: iraf-core.pkg
 		 --version 2.8.5 \
 	         $@
 
-sptable.pkg: iraf-core.pkg
+sptable.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/sptable
 	curl -L https://github.com/iraf-community/iraf-sptable/archive/refs/tags/1.0.pre20180612.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/sptable --strip-components=1
@@ -172,7 +172,7 @@ sptable.pkg: iraf-core.pkg
 		 --version 1.0.pre20180612 \
 	         $@
 
-st4gem.pkg: iraf-core.pkg
+st4gem.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/st4gem
 	curl -L https://gitlab.com/nsf-noirlab/csdc/usngo/iraf/st4gem/-/archive/1.0/st4gem-1.0.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/st4gem --strip-components=1
@@ -191,7 +191,7 @@ st4gem.pkg: iraf-core.pkg
 		 --version 1.0 \
 	         $@
 
-xdimsum.pkg: iraf-core.pkg
+xdimsum.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/xdimsum
 	curl -L https://github.com/iraf-community/iraf-xdimsum/archive/refs/heads/main.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/xdimsum --strip-components=1

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ export RMFILES=$(iraf)unix/bin/rmfiles.e
 
 export CFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) -O2
 export LDFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) -O2
-export XC_CFLAGS = $(CFLAGS)
-export XC_LFLAGS = $(LDFLAGS)
+export XC_CFLAGS = $(CFLAGS) -I$(BUILDDIR)/cfitsio
+export XC_LFLAGS = $(LDFLAGS) -L$(BUILDDIR)/cfitsio
 
 PATH += :$(BINDIR)
 
@@ -89,13 +89,15 @@ ctio.pkg: core.pkg
 		 --version 0+2023-11-12 \
 	         $@
 
-fitsutil.pkg: core.pkg
+# libcfitsio.a is required for fitsutil
+$(BUILDDIR)/cfitsio/libcfitsio.a:
 	mkdir -p $(BUILDDIR)/cfitsio
 	curl -L https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.4.0.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/cfitsio --strip-components=1
-	( cd $(BUILDDIR)/cfitsio && \
-	  ./configure --disable-curl && \
-	  $(MAKE) libcfitsio.a )
+	cd $(BUILDDIR)/cfitsio && ./configure --disable-curl
+	$(MAKE) -C $(BUILDDIR)/cfitsio libcfitsio.a
+
+fitsutil.pkg: core.pkg $(BUILDDIR)/cfitsio/libcfitsio.a
 	mkdir -p $(BUILDDIR)/fitsutil
 	curl -L https://github.com/iraf-community/iraf-fitsutil/archive/refs/heads/main.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/fitsutil --strip-components=1
@@ -103,10 +105,7 @@ fitsutil.pkg: core.pkg
 	  rm -rf bin* && \
 	  mkdir -p bin.$(IRAFARCH) && \
 	  ln -s bin.$(IRAFARCH) bin && \
-	  $(MKPKG) -p fitsutil \
-		   fitsutil=$(BUILDDIR)/fitsutil/ \
-		   XC_LFLAGS="$(XC_LFLAGS) -L$(BUILDDIR)/cfitsio" \
-		   XC_CFLAGS="$(XC_CFLAGS) -I$(BUILDDIR)/cfitsio" )
+	  $(MKPKG) -p fitsutil fitsutil=$(BUILDDIR)/fitsutil/ )
 	find $(BUILDDIR)/fitsutil -name \*.[eao] -type f \
 	     -exec codesign -s - -i community.iraf.fitsutil {} \;
 	pkgbuild --identifier community.iraf.fitsutil \

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ endif
 export MKPKG=$(iraf)unix/bin/mkpkg.e
 export RMFILES=$(iraf)unix/bin/rmfiles.e
 
-export CFLAGS = -mmacosx-version-min=$(MINVERSION) -O2
-export LDFLAGS = -mmacosx-version-min=$(MINVERSION) -O2
+export CFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) -O2
+export LDFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) -O2
 export XC_CFLAGS = $(CFLAGS)
 export XC_LFLAGS = $(LDFLAGS)
 

--- a/distribution.plist
+++ b/distribution.plist
@@ -29,7 +29,7 @@
       </line>
     </choices-outline>
     <choice id="community.iraf.core" title="IRAF core" enabled="false">
-      <pkg-ref id="community.iraf.core">iraf-core.pkg</pkg-ref>
+      <pkg-ref id="community.iraf.core">core.pkg</pkg-ref>
     </choice>
     <choice id="community.iraf.x11iraf" title="xgterm and ximtool">
       <pkg-ref id="community.iraf.x11iraf">x11iraf.pkg</pkg-ref>


### PR DESCRIPTION
Be however aware that this takes very much time, as the x86_86 binaries are also used to build IRAF (longer that allowed on Github Actions).

Also, we rename the core package to `core.pkg`, so that we can refer to the main package with `iraf-*.pkg`.

And finally we separate the libcfitsio build from the fitsutil build. This was meant to go to #2, but somehow was left out.