### PR TITLE
Point xgterm to local terminfo file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ x11iraf.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/x11iraf
 	curl -L https://github.com/iraf-community/x11iraf/archive/refs/tags/v2.1.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/x11iraf --strip-components=1
+	patch -d $(BUILDDIR)/x11iraf -p1 < patches/x11iraf/0001-Force-setting-of-local-terminfo-database.patch
 	$(MAKE) -C $(BUILDDIR)/x11iraf
 	mkdir -p $(INSTDIR)/x11/usr/local/bin $(INSTDIR)/x11/usr/local/share/man/man1 $(INSTDIR)/x11/usr/local/share/terminfo
 	install -m755 $(BUILDDIR)/x11iraf/xgterm/xgterm $(INSTDIR)/x11/usr/local/bin

--- a/patches/x11iraf/0001-Force-setting-of-local-terminfo-database.patch
+++ b/patches/x11iraf/0001-Force-setting-of-local-terminfo-database.patch
@@ -1,0 +1,24 @@
+From 0bb53427cf4b80671fe1279bb355d4130d62b4d8 Mon Sep 17 00:00:00 2001
+From: Ole Streicher <olebole@debian.org>
+Date: Fri, 15 Mar 2024 15:44:54 +0100
+Subject: [PATCH] Force setting of local terminfo database
+
+---
+ xgterm/main.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xgterm/main.c b/xgterm/main.c
+index 2ec1437..7d4cd10 100644
+--- a/xgterm/main.c
++++ b/xgterm/main.c
+@@ -1026,6 +1026,7 @@ char **argv;
+ #ifdef I18N
+         setlocale(LC_ALL, NULL);
+ #endif
++	putenv("TERMINFO=/usr/local/share/terminfo");
+ 
+ 	ProgramName = argv[0];
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
On macOS, new terminfo files cannot be installed in `/usr/share/terminfo/` (restricted access), however there are only two places which are read out by default: this system wide one, and the user's one. **xgterm** however works only if it comes with the correct terminfo file (produced by **tic**).

To force **xgterm** read in a non-default terminfo, the environment variable `TERMINFO` must be set. This is done by defining injecting this variable unconditionally at program start. The dedicated way to use the `OWN_TERMINFO_DIR` doesn't work because the terminal type (`TERM`) is set before `OWN_TERMINFO_DIR` is set.