### PR TITLE
Switch to released 2.17.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INSTDIR=$(shell pwd)/install
 BUILDDIR=$(shell pwd)/build
 BINDIR=$(shell pwd)/bin
 
-MINVERSION = 10.15
+MINVERSION = 10.10
 MACARCH=$(shell uname -m)
 
 export iraf=$(BUILDDIR)/iraf/
@@ -34,7 +34,7 @@ PKGS = core.pkg x11iraf.pkg ctio.pkg fitsutil.pkg mscred.pkg	\
 
 core.pkg:
 	mkdir -p $(BUILDDIR)/iraf
-	curl -L https://github.com/iraf-community/iraf/archive/c420938.tar.gz | \
+	curl -L https://github.com/iraf-community/iraf/archive/refs/tags/v2.17.1.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/iraf --strip-components=1
 	$(MAKE) -C $(BUILDDIR)/iraf
 	mkdir -p $(INSTDIR)/iraf
@@ -47,7 +47,7 @@ core.pkg:
 	         --root $(INSTDIR)/iraf \
 		 --install-location / \
 		 --min-os-version $(MINVERSION) \
-		 --version 2.17.1+ \
+		 --version 2.17.1 \
 	         $@
 
 x11iraf.pkg: core.pkg

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ export RMFILES=$(iraf)unix/bin/rmfiles.e
 
 export CFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) -O2
 export LDFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) -O2
-export XC_CFLAGS = $(CFLAGS) -I$(BUILDDIR)/cfitsio
-export XC_LFLAGS = $(LDFLAGS) -L$(BUILDDIR)/cfitsio
+export XC_CFLAGS = $(CFLAGS) -I$(iraf)include
+export XC_LFLAGS = $(LDFLAGS)
 
 PATH += :$(BINDIR)
 
@@ -93,15 +93,7 @@ ctio.pkg: core.pkg
 		 --version 0+2023-11-12 \
 	         $@
 
-# libcfitsio.a is required for fitsutil
-$(BUILDDIR)/cfitsio/libcfitsio.a:
-	mkdir -p $(BUILDDIR)/cfitsio
-	curl -L https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.4.0.tar.gz | \
-	  tar xzf - -C $(BUILDDIR)/cfitsio --strip-components=1
-	cd $(BUILDDIR)/cfitsio && ./configure --disable-curl
-	$(MAKE) -C $(BUILDDIR)/cfitsio libcfitsio.a
-
-fitsutil.pkg: core.pkg $(BUILDDIR)/cfitsio/libcfitsio.a
+fitsutil.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/fitsutil
 	curl -L https://github.com/iraf-community/iraf-fitsutil/archive/0858bbb.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/fitsutil --strip-components=1
@@ -109,7 +101,7 @@ fitsutil.pkg: core.pkg $(BUILDDIR)/cfitsio/libcfitsio.a
 	  rm -rf bin* && \
 	  mkdir -p bin.$(IRAFARCH) && \
 	  ln -s bin.$(IRAFARCH) bin && \
-	  $(MKPKG) -p fitsutil fitsutil=$(BUILDDIR)/fitsutil/ )
+	  fitsutil=$(BUILDDIR)/fitsutil/ $(MKPKG) -p fitsutil )
 	find $(BUILDDIR)/fitsutil -name \*.[eao] -type f \
 	     -exec codesign -s - -i community.iraf.fitsutil {} \;
 	pkgbuild --identifier community.iraf.fitsutil \

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ core.pkg:
 	mkdir -p $(BUILDDIR)/iraf
 	curl -L https://github.com/iraf-community/iraf/archive/refs/tags/v2.17.1.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/iraf --strip-components=1
+	patch -d $(BUILDDIR)/iraf -p1 < patches/core/0001-fix-DESTDIR-in-Makefile.patch
+	patch -d $(BUILDDIR)/iraf -p1 < patches/core/0002-Create-bindir-and-includedir-on-libvotable-install.patch
 	$(MAKE) -C $(BUILDDIR)/iraf
 	mkdir -p $(INSTDIR)/iraf
 	$(MAKE) -C $(BUILDDIR)/iraf DESTDIR=$(INSTDIR)/iraf install

--- a/patches/core/0001-fix-DESTDIR-in-Makefile.patch
+++ b/patches/core/0001-fix-DESTDIR-in-Makefile.patch
@@ -1,0 +1,21 @@
+From: Ole Streicher <olebole@debian.org>
+Date: Sat, 15 Jul 2023 19:55:41 +0200
+Subject: fix DESTDIR in Makefile
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 3786734..40529ff 100644
+--- a/Makefile
++++ b/Makefile
+@@ -180,7 +180,7 @@ prefix ?= /usr/local
+ install: noao/bin/x_quad.e
+ 	mkdir -p $(DESTDIR)$(prefix)/lib/iraf $(DESTDIR)$(prefix)/bin $(DESTDIR)$(prefix)/share/man/man1 $(DESTDIR)/etc/iraf
+ 	cp -a -f bin* dev extern include lib local math mkpkg noao pkg sys test unix \
+-	         $(prefix)/lib/iraf
++	         $(DESTDIR)$(prefix)/lib/iraf
+ 	$(MAKE) config binary_links strip iraf=$(prefix)/lib/iraf/ bindir=$(prefix)/bin
+ 	cp -f $(hlib)mkiraf.man $(DESTDIR)$(prefix)/share/man/man1/mkiraf.1
+ 	cp -f $(hlib)ecl.man $(DESTDIR)$(prefix)/share/man/man1/ecl.1

--- a/patches/core/0002-Create-bindir-and-includedir-on-libvotable-install.patch
+++ b/patches/core/0002-Create-bindir-and-includedir-on-libvotable-install.patch
@@ -1,0 +1,20 @@
+From: Ole Streicher <olebole@debian.org>
+Date: Sat, 15 Jul 2023 19:23:18 +0200
+Subject: Create bindir and includedir on libvotable install
+
+---
+ vendor/libvotable/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/vendor/libvotable/Makefile b/vendor/libvotable/Makefile
+index f4dad42..10b050b 100644
+--- a/vendor/libvotable/Makefile
++++ b/vendor/libvotable/Makefile
+@@ -12,6 +12,7 @@ libVOTable.a: $(OBJS)
+ 	ar r $@ $?
+ 
+ install: libVOTable.a
++	mkdir -p $(bindir) $(includedir)
+ 	cp libVOTable.a $(bindir)
+ 	cp $(INCS) $(includedir)
+ 


### PR DESCRIPTION
It may be useful to (soonish) publish an installer based on the currently released 2.17.1 instead of a development version.

This PR switches to 2.17.1, and also removes the external cfitsio package (which is already included in IRAF 2.17.1).