### PR TITLE
Restructure package selection

### DIFF
--- a/distribution.plist
+++ b/distribution.plist
@@ -28,7 +28,8 @@
 	<line choice="community.iraf.xdimsum"/>
       </line>
     </choices-outline>
-    <choice id="community.iraf.core" title="IRAF core" enabled="false">
+    <choice id="community.iraf.core" title="IRAF"
+	    description="IRAF core package">
       <pkg-ref id="community.iraf.core">core.pkg</pkg-ref>
     </choice>
     <choice id="community.iraf.x11iraf" title="xgterm and ximtool">

--- a/distribution.plist
+++ b/distribution.plist
@@ -18,56 +18,53 @@
     <choices-outline>
       <line choice="community.iraf.core"/>
       <line choice="community.iraf.x11iraf"/>
-      <line choice="community.iraf.external">
-	<line choice="community.iraf.ctio"/>
-	<line choice="community.iraf.fitsutil"/>
-	<line choice="community.iraf.mscred"/>
-	<line choice="community.iraf.rvsao"/>
-	<line choice="community.iraf.sptable"/>
-	<line choice="community.iraf.st4gem"/>
-	<line choice="community.iraf.xdimsum"/>
-      </line>
+      <line choice="community.iraf.ctio"/>
+      <line choice="community.iraf.fitsutil"/>
+      <line choice="community.iraf.mscred"/>
+      <line choice="community.iraf.rvsao"/>
+      <line choice="community.iraf.sptable"/>
+      <line choice="community.iraf.st4gem"/>
+      <line choice="community.iraf.xdimsum"/>
     </choices-outline>
     <choice id="community.iraf.core" title="IRAF"
-	    description="IRAF core package">
+	    description="IRAF core and NOAO package">
       <pkg-ref id="community.iraf.core">core.pkg</pkg-ref>
     </choice>
     <choice id="community.iraf.x11iraf" title="X11IRAF"
 	    description="X11 terminal emulator (xgterm) and interactive image display (ximtool)">
       <pkg-ref id="community.iraf.x11iraf">x11iraf.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.external" title="External packages"/>
-    <choice id="community.iraf.ctio" title="ctio"
+    <choice id="community.iraf.ctio" title="External: ctio"
 	    description="Tools from the Cerro Tololo Inter-American Observatory"
 	    start_selected="false">
       <pkg-ref id="community.iraf.ctio">ctio.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.fitsutil" title="fitsutil"
+    <choice id="community.iraf.fitsutil" title="External: fitsutil"
 	    description="Utilities for single and multiple FITS files"
 	    start_selected="false">
       <pkg-ref id="community.iraf.fitsutil">fitsutil.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.mscred" title="mscred"
+    <choice id="community.iraf.mscred" title="External: mscred"
 	    description="Mosaic CCD reduction package"
 	    start_selected="false">
       <pkg-ref id="community.iraf.mscred">mscred.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.rvsao" title="rvsao"
+    <choice id="community.iraf.rvsao" title="External: rvsao"
 	    description="Radial velocity package"
 	    start_selected="false">
       <pkg-ref id="community.iraf.rvsao">rvsao.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.sptable" title="sptable"
+    <choice id="community.iraf.sptable" title="External: sptable"
 	    description="Tabular spectra package"
 	    start_selected="false">
       <pkg-ref id="community.iraf.sptable">sptable.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.st4gem" title="st4gem"
+    <choice id="community.iraf.st4gem" title="External: st4gem"
 	    description="Selected tasks from STSDAS"
 	    start_selected="false">
       <pkg-ref id="community.iraf.st4gem">st4gem.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.xdimsum" title="xdimsum"
+    <choice id="community.iraf.xdimsum" title="External: xdimsum"
 	    description=" Deep Infrared Mosaicing Software"
 	    start_selected="false">
       <pkg-ref id="community.iraf.xdimsum">xdimsum.pkg</pkg-ref>

--- a/distribution.plist
+++ b/distribution.plist
@@ -32,29 +32,44 @@
 	    description="IRAF core package">
       <pkg-ref id="community.iraf.core">core.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.x11iraf" title="xgterm and ximtool">
+    <choice id="community.iraf.x11iraf" title="X11IRAF"
+	    description="X11 terminal emulator (xgterm) and interactive image display (ximtool)">
       <pkg-ref id="community.iraf.x11iraf">x11iraf.pkg</pkg-ref>
     </choice>
     <choice id="community.iraf.external" title="External packages"/>
-    <choice id="community.iraf.ctio" title="ctio" start_selected="false">
+    <choice id="community.iraf.ctio" title="ctio"
+	    description="Tools from the Cerro Tololo Inter-American Observatory"
+	    start_selected="false">
       <pkg-ref id="community.iraf.ctio">ctio.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.fitsutil" title="fitsutil" start_selected="false">
+    <choice id="community.iraf.fitsutil" title="fitsutil"
+	    description="Utilities for single and multiple FITS files"
+	    start_selected="false">
       <pkg-ref id="community.iraf.fitsutil">fitsutil.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.mscred" title="mscred" start_selected="false">
+    <choice id="community.iraf.mscred" title="mscred"
+	    description="Mosaic CCD reduction package"
+	    start_selected="false">
       <pkg-ref id="community.iraf.mscred">mscred.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.rvsao" title="rvsao" start_selected="false">
+    <choice id="community.iraf.rvsao" title="rvsao"
+	    description="Radial velocity package"
+	    start_selected="false">
       <pkg-ref id="community.iraf.rvsao">rvsao.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.sptable" title="sptable" start_selected="false">
+    <choice id="community.iraf.sptable" title="sptable"
+	    description="Tabular spectra package"
+	    start_selected="false">
       <pkg-ref id="community.iraf.sptable">sptable.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.st4gem" title="st4gem" start_selected="false">
+    <choice id="community.iraf.st4gem" title="st4gem"
+	    description="Selected tasks from STSDAS"
+	    start_selected="false">
       <pkg-ref id="community.iraf.st4gem">st4gem.pkg</pkg-ref>
     </choice>
-    <choice id="community.iraf.xdimsum" title="xdimsum" start_selected="false">
+    <choice id="community.iraf.xdimsum" title="xdimsum"
+	    description=" Deep Infrared Mosaicing Software"
+	    start_selected="false">
       <pkg-ref id="community.iraf.xdimsum">xdimsum.pkg</pkg-ref>
     </choice>
 </installer-gui-script>


### PR DESCRIPTION
This PR makes the IRAF package itself optional (but pre-selected), adds descriptions to all selection items, and simplifies/flattens the selection (i.e. no "External packages" substructure).