### PR TITLE
Make success screen more looking like the standard one

### DIFF
--- a/conclusion.html
+++ b/conclusion.html
@@ -16,6 +16,10 @@
   <body>
     <p style="text-align:center; font-size:42pt;margin-bottom: 0px;margin-top: 24px;">&#9989;</p>
     <h2 style="text-align:center">The installation was successful.</h1>
+    <p style="text-aligh:center">
+      You can now use the usual IRAF commands like <b>xgterm</b> and <b>ecl</b>.
+    </p>
+    <!--
     <p style="text-align:center">
       You can now start a graphical terminal and IRAF with the
       command
@@ -23,6 +27,7 @@
     <p style="text-align:center">
       <code>irafcl -x</code>
     </p>
+    -->
     <p style="text-align:center">
       For more information, check the IRAF homepage
     </p>

--- a/conclusion.html
+++ b/conclusion.html
@@ -14,16 +14,16 @@
     </style>
   </head>
   <body>
-    <h1>Congratulations!</h1>
-    <h2>&#9989; Installation complete</h2>
-    <p>
+    <p style="text-align:center; font-size:42pt;margin-bottom: 0px;margin-top: 24px;">&#9989;</p>
+    <h2 style="text-align:center">The installation was successful.</h1>
+    <p style="text-align:center">
       You can now start a graphical terminal and IRAF with the
       command
     </p>
     <p style="text-align:center">
       <code>irafcl -x</code>
     </p>
-    <p>
+    <p style="text-align:center">
       For more information, check the IRAF homepage
     </p>
     <p style="text-align:center">
@@ -31,7 +31,7 @@
     </p>
 
     <h2>Credits</h2>
-    <p>
+    <p style="margin-bottom:0pt">
       This installation was prepared by Ole Streicher for the IRAF
       community. IRAF however was maintained over the years by a
       number of institutions and volunteers, providing code, bug


### PR DESCRIPTION
How the success screen looks by default: 

![grafik](https://github.com/iraf-community/iraf-mac-build/assets/397223/f5975b3f-acbb-42af-9439-e6633668e725)

This PR also shows a large central green hook (although a rectangular one) and the sucess message so that the success screen looks like this:

![image](https://github.com/iraf-community/iraf-mac-build/assets/397223/fa2baed7-1dc8-44b8-9312-7957f1dc8111)

Also, the hint for the user was changed because 2.17.1 does not come with an `irafcl`command.