### PR TITLE
st4gem: Add missing default fourier transform coordinate-type pairs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ st4gem.pkg: core.pkg
 	mkdir -p $(BUILDDIR)/st4gem
 	curl -L https://gitlab.com/nsf-noirlab/csdc/usngo/iraf/st4gem/-/archive/1.0/st4gem-1.0.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/st4gem --strip-components=1
+	patch -d $(BUILDDIR)/st4gem -p1 < st4gem/patches/0001-Add-missing-default-fourier-transform-coordinate-typ.patch
 	( cd $(BUILDDIR)/st4gem && \
 	  rm -rf bin* && \
 	  mkdir -p bin.$(IRAFARCH) && \

--- a/st4gem/patches/0001-Add-missing-default-fourier-transform-coordinate-typ.patch
+++ b/st4gem/patches/0001-Add-missing-default-fourier-transform-coordinate-typ.patch
@@ -1,0 +1,46 @@
+From f10a048cdfcffc052b284eade0c1eeb26f5b36f9 Mon Sep 17 00:00:00 2001
+From: Ole Streicher <olebole@debian.org>
+Date: Sun, 24 Mar 2024 11:39:29 +0100
+Subject: [PATCH] Add missing default fourier transform coordinate-type pairs
+
+They seem to were lost when fourier was extracted from STSDAS
+
+https://gitlab.com/nsf-noirlab/csdc/usngo/iraf/st4gem/-/issues/7
+---
+ pkg/analysis/fourier/ftpairs.dat | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+ create mode 100644 pkg/analysis/fourier/ftpairs.dat
+
+diff --git a/pkg/analysis/fourier/ftpairs.dat b/pkg/analysis/fourier/ftpairs.dat
+new file mode 100644
+index 0000000..6dde124
+--- /dev/null
++++ b/pkg/analysis/fourier/ftpairs.dat
+@@ -0,0 +1,24 @@
++# Fourier transform coordinate-type pairs.
++# FITS standard CTYPEs are used where possible.
++
++TIME       FREQ
++
++LAMBDA     WAVENUMB
++
++VELO       FTVELO	# Velocity, spatial frequency
++
++PIXEL      PIXEL
++
++LL         UU		# E-W tangent plane, U coordinate of visibility
++MM         VV		# N-S tangent plane, V coordinate of visibility
++NN         WW		# normal (radial) "plane", W coordinate of visibility
++
++RA         FTRA		# Equatorial coords
++DEC        FTDEC
++RA---TAN   FTRA-T	# Equatorial coords
++DEC--TAN   FTDEC-T
++
++GLON       FTGLON	# Galactic coords
++GLAT       FTGLAT
++
++ANGLE      FTANGLE	# Arbitrary angular separation
+-- 
+2.43.0
+


### PR DESCRIPTION
This file is missing in st4gem. 

Original issue: [noirlag/st4gem#7](https://gitlab.com/nsf-noirlab/csdc/usngo/iraf/st4gem/-/issues/7)