### PR TITLE
Don't use arch dependent dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,15 @@ BINDIR = $(shell pwd)/bin
 MACARCH = $(shell uname -m)
 
 export iraf = $(BUILDDIR)/iraf/
+export IRAFARCH=
 
 ifeq ($(MACARCH), arm64)
-  export IRAFARCH = macos64
   MINVERSION = 11
   PKGBUILD_ARG = --min-os-version $(MINVERSION)
 else ifeq ($(MACARCH), x86_64)
-  export IRAFARCH = macintel
   MINVERSION = 10.10
   PKGBUILD_ARG = --min-os-version $(MINVERSION)
 else # i386
-  export IRAFARCH = macosx
   MINVERSION = 10.6
   PKGBUILD_ARG =
 endif
@@ -49,7 +47,7 @@ core.pkg:
 	patch -d $(BUILDDIR)/iraf -p1 < core/patches/0002-Create-bindir-and-includedir-on-libvotable-install.patch
 	$(MAKE) -C $(BUILDDIR)/iraf
 	mkdir -p $(INSTDIR)/iraf
-	$(MAKE) -C $(BUILDDIR)/iraf DESTDIR=$(INSTDIR)/iraf install
+	$(MAKE) -C $(BUILDDIR)/iraf DESTDIR=$(INSTDIR)/iraf install 
 	find $(INSTDIR)/iraf -name \*.[eao] -type f \
 	     -exec codesign -s - -i community.iraf.core {} \;
 	mkdir -p bin
@@ -124,8 +122,7 @@ ctio.pkg: core.pkg
 	  tar xzf - -C $(BUILDDIR)/ctio --strip-components=1
 	( cd $(BUILDDIR)/ctio && \
 	  rm -rf bin* && \
-	  mkdir -p bin.$(IRAFARCH) && \
-	  ln -s bin.$(IRAFARCH) bin && \
+	  mkdir -p bin && \
 	  ctio=$(BUILDDIR)/ctio/ $(MKPKG) -p ctio && \
 	  $(RMFILES) -f lib/strip.ctio )
 	find $(BUILDDIR)/ctio -name \*.[eao] -type f \
@@ -143,8 +140,7 @@ fitsutil.pkg: core.pkg
 	  tar xzf - -C $(BUILDDIR)/fitsutil --strip-components=1
 	( cd $(BUILDDIR)/fitsutil && \
 	  rm -rf bin* && \
-	  mkdir -p bin.$(IRAFARCH) && \
-	  ln -s bin.$(IRAFARCH) bin && \
+	  mkdir -p bin && \
 	  fitsutil=$(BUILDDIR)/fitsutil/ $(MKPKG) -p fitsutil )
 	find $(BUILDDIR)/fitsutil -name \*.[eao] -type f \
 	     -exec codesign -s - -i community.iraf.fitsutil {} \;
@@ -161,8 +157,7 @@ mscred.pkg: core.pkg
 	  tar xzf - -C $(BUILDDIR)/mscred --strip-components=1
 	( cd $(BUILDDIR)/mscred && \
 	  rm -rf bin* && \
-	  mkdir -p bin.$(IRAFARCH) && \
-	  ln -s bin.$(IRAFARCH) bin && \
+	  mkdir -p bin && \
 	  mscred=$(BUILDDIR)/mscred/ $(MKPKG) -p mscred)
 	find $(BUILDDIR)/mscred -name \*.[eao] -type f \
 	     -exec codesign -s - -i community.iraf.mscred {} \;
@@ -180,8 +175,7 @@ rvsao.pkg: core.pkg
 	patch -d $(BUILDDIR)/rvsao -p1 < rvsao/patches/0001-Add-NOAO-into-build-search-path.patch
 	( cd $(BUILDDIR)/rvsao && \
 	  rm -rf bin* && \
-	  mkdir -p bin.$(IRAFARCH) && \
-	  ln -s bin.$(IRAFARCH) bin && \
+	  mkdir -p bin && \
 	  rvsao=$(BUILDDIR)/rvsao/ $(MKPKG) -p rvsao)
 	find $(BUILDDIR)/rvsao -name \*.[eao] -type f \
 	     -exec codesign -s - -i community.iraf.rvsao {} \;
@@ -198,8 +192,7 @@ sptable.pkg: core.pkg
 	  tar xzf - -C $(BUILDDIR)/sptable --strip-components=1
 	( cd $(BUILDDIR)/sptable && \
 	  rm -rf bin* && \
-	  mkdir -p bin.$(IRAFARCH) && \
-	  ln -s bin.$(IRAFARCH) bin && \
+	  mkdir -p bin && \
 	  sptable=$(BUILDDIR)/sptable/ $(MKPKG) -p sptable && \
 	  $(RMFILES) -f lib/strip.sptable )
 	find $(BUILDDIR)/sptable -name \*.[eao] -type f \
@@ -218,8 +211,7 @@ st4gem.pkg: core.pkg
 	patch -d $(BUILDDIR)/st4gem -p1 < st4gem/patches/0001-Add-missing-default-fourier-transform-coordinate-typ.patch
 	( cd $(BUILDDIR)/st4gem && \
 	  rm -rf bin* && \
-	  mkdir -p bin.$(IRAFARCH) && \
-	  ln -s bin.$(IRAFARCH) bin && \
+	  mkdir -p bin && \
 	  st4gem=$(BUILDDIR)/st4gem/ $(MKPKG) -p st4gem && \
 	  $(RMFILES) -f lib/strip.st4gem )
 	find $(BUILDDIR)/st4gem -name \*.[eao] -type f \
@@ -237,8 +229,7 @@ xdimsum.pkg: core.pkg
 	  tar xzf - -C $(BUILDDIR)/xdimsum --strip-components=1
 	( cd $(BUILDDIR)/xdimsum && \
 	  rm -rf bin* && \
-	  mkdir -p bin.$(IRAFARCH) && \
-	  ln -s bin.$(IRAFARCH) bin && \
+	  mkdir -p bin && \
 	  xdimsum=$(BUILDDIR)/xdimsum/ $(MKPKG) -p xdimsum && \
 	  $(RMFILES) -f lib/strip.xdimsum )
 	find $(BUILDDIR)/xdimsum -name \*.[eao] -type f \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ core.pkg:
 	  tar xzf - -C $(BUILDDIR)/iraf --strip-components=1
 	patch -d $(BUILDDIR)/iraf -p1 < core/patches/0001-fix-DESTDIR-in-Makefile.patch
 	patch -d $(BUILDDIR)/iraf -p1 < core/patches/0002-Create-bindir-and-includedir-on-libvotable-install.patch
+	patch -d $(BUILDDIR)/iraf -p1 < core/patches/0003-Allow-empty-IRAFARCH-in-irafpath.patch
 	$(MAKE) -C $(BUILDDIR)/iraf
 	mkdir -p $(INSTDIR)/iraf
 	$(MAKE) -C $(BUILDDIR)/iraf DESTDIR=$(INSTDIR)/iraf install 

--- a/core/patches/0003-Allow-empty-IRAFARCH-in-irafpath.patch
+++ b/core/patches/0003-Allow-empty-IRAFARCH-in-irafpath.patch
@@ -1,0 +1,36 @@
+From b8d770528351a017da822b0985de62986198fcdf Mon Sep 17 00:00:00 2001
+From: Ole Streicher <olebole@debian.org>
+Date: Mon, 1 Apr 2024 00:15:05 +0200
+Subject: [PATCH] Allow empty IRAFARCH in irafpath()
+
+---
+ unix/os/irafpath.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/unix/os/irafpath.c b/unix/os/irafpath.c
+index 06da15616..55b087e4b 100644
+--- a/unix/os/irafpath.c
++++ b/unix/os/irafpath.c
+@@ -71,7 +71,8 @@ irafpath (char *fname)
+ 	 */
+ 	strcpy (pathname, (char *)hostdir);
+ 	strcat (pathname, "bin");
+-	if ( (irafarch = getenv("IRAFARCH")) ) {
++	if ( (irafarch = getenv("IRAFARCH"))
++	     && (strlen(irafarch) > 0) ) {
+ 	    strcat (pathname, ".");
+ 	    strcat (pathname, irafarch);
+ 	}
+@@ -90,7 +91,8 @@ irafpath (char *fname)
+ 	/* Try BIN - use IRAFARCH if defined. */
+ 	strcpy (pathname, (char *)irafdir);
+ 	strcat (pathname, "bin");
+-	if ( (irafarch = getenv("IRAFARCH")) ) {
++	if ( (irafarch = getenv("IRAFARCH"))
++	     && (strlen(irafarch) > 0) ) {
+ 	    strcat (pathname, ".");
+ 	    strcat (pathname, irafarch);
+ 	}
+-- 
+2.43.0
+


### PR DESCRIPTION
Architecture dependent dirs may be useful for special needs (cross compilation) but they make things for the end user more
complicated.

As in the current Linux binary packages, this patch removes them, i.e. `bin` is no longer a link to `bin.$IRAFARCH`, but a simple directory with the binaries in.
