### PR TITLE
Fix the installation of the TERMINFO database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ xgterm.pkg: ximtool.pkg # This re-uses the same build as ximtool
 	         xgterm/XGTerm.iconset/
 	install $(BUILDDIR)/x11iraf/xgterm/xgterm.man \
 	        $(INSTDIR)/xgterm/XGTerm.app/Contents/Resources/man/xgterm.1
-	TERMINFO=$(INSTDIR)/xgterm/XGTerm.app/Resources/terminfo tic \
+	tic -v -o $(INSTDIR)/xgterm/XGTerm.app/Contents/Resources/terminfo \
 	        $(BUILDDIR)/x11iraf/xgterm/xgterm.terminfo
 	codesign -s - -i community.iraf.xgterm $(INSTDIR)/xgterm/XGTerm.app
 	pkgbuild --identifier community.iraf.xgterm \

--- a/xgterm/scripts/postinstall
+++ b/xgterm/scripts/postinstall
@@ -11,7 +11,6 @@ APP_PATH=$2
 mkdir -p /usr/local/bin/ /usr/local/share/man/man1/ /usr/local/share/terminfo/78
 
 XGTERM_PATH=${APP_PATH}/XGTerm.app/Contents/Resources
-rm -f /usr/local/bin/xgterm /usr/local/share/man/man1/xgterm.1 /usr/local/share/terminfo/78/xgterm
-ln -s ${XGTERM_PATH}/bin/xgterm /usr/local/bin/
-ln -s ${XGTERM_PATH}/man/xgterm.1 /usr/local/share/man/man1/
-ln -s ${XGTERM_PATH}/terminfo/78/xgterm /usr/local/share/terminfo/78/
+ln -sf ${XGTERM_PATH}/bin/xgterm /usr/local/bin/
+ln -sf ${XGTERM_PATH}/man/xgterm.1 /usr/local/share/man/man1/
+ln -sf ${XGTERM_PATH}/terminfo/78/xgterm /usr/local/share/terminfo/78/


### PR DESCRIPTION
This was accidently not put into CONTENT and therefore was not part of the xgterm package.