### PR TITLE
Lower optimization level for macintel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: macOS 12 (Intel)
-            os: macos-12
+          - name: arm64
+            os: macos-latest
+            arch: arm64
 
-          - name: macOS 15 (M1)
-            os: macos-15
+          - name: x86_64
+            os: macos-latest
+            arch: x86_64
 
     env:
       TERM: ansi
@@ -39,7 +41,7 @@ jobs:
           
       - name: Build package
         run: |
-           make -j 4
+           make -j 4 MACARCH=${{ matrix.arch }}
 
       - name: Locally test package installation
         run: |

--- a/Makefile
+++ b/Makefile
@@ -15,19 +15,22 @@ export IRAFARCH=
 ifeq ($(MACARCH), arm64)
   MINVERSION = 11
   PKGBUILD_ARG = --min-os-version $(MINVERSION)
+  OPT = -O2
 else ifeq ($(MACARCH), x86_64)
   MINVERSION = 10.10
   PKGBUILD_ARG = --min-os-version $(MINVERSION)
+  OPT = -O1
 else # i386
   MINVERSION = 10.6
   PKGBUILD_ARG =
+  OBT = -O2
 endif
 
 export MKPKG=$(iraf)unix/bin/mkpkg.e
 export RMFILES=$(iraf)unix/bin/rmfiles.e
 
-export CFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) -O2
-export LDFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) -O2
+export CFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) $(OPT)
+export LDFLAGS = -mmacosx-version-min=$(MINVERSION) -arch $(MACARCH) $(OPT)
 export XC_CFLAGS = $(CFLAGS) -I$(BUILDDIR)/cfitsio
 export XC_LFLAGS = $(LDFLAGS) -L$(BUILDDIR)/cfitsio/.libs
 


### PR DESCRIPTION
Compile on macintel only with `-O1`
    
Reason is that with `-O2` the compilation on macintel is buggy and `rmfiles.e unix/hlib/strip.iraf` fails with
    
        illegal `-f progfile' switch
    
This seems a compiler bug, as there is nothing in `rmfiles.c` that  could cause this.

This PR also updates the build platforms on Github to macos-latest; using the arch to differentiate.