### PR TITLE
Fix 32-bit build of (E)CL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ core.pkg:
 	mkdir -p $(BUILDDIR)/iraf
 	curl -L https://github.com/iraf-community/iraf/archive/refs/tags/v2.18.1rc2.tar.gz | \
 	  tar xzf - -C $(BUILDDIR)/iraf --strip-components=1
+	patch -d $(BUILDDIR)/iraf -p1 < \
+	      iraf/patches/0001-Fix-type-of-jumpcon-in-e-cl-main.c.patch
 	$(MAKE) -C $(BUILDDIR)/iraf
 	mkdir -p $(INSTDIR)/iraf
 	$(MAKE) -C $(BUILDDIR)/iraf DESTDIR=$(INSTDIR)/iraf install 

--- a/iraf/patches/0001-Fix-type-of-jumpcon-in-e-cl-main.c.patch
+++ b/iraf/patches/0001-Fix-type-of-jumpcon-in-e-cl-main.c.patch
@@ -1,0 +1,53 @@
+From: Ole Streicher <olebole@debian.org>
+Date: Sun, 18 Aug 2024 23:20:14 +0200
+Subject: Fix type of jumpcon in (e)cl/main.c
+
+---
+ pkg/cl/main.c  | 4 ++--
+ pkg/ecl/main.c | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/pkg/cl/main.c b/pkg/cl/main.c
+index 36ba3ef..ee62d41 100644
+--- a/pkg/cl/main.c
++++ b/pkg/cl/main.c
+@@ -63,7 +63,7 @@ int	cldebug = 0;		/* print out lots of goodies if > 0	*/
+ int	cltrace = 0;		/* trace instruction execution if > 0	*/
+ 
+ static	funcptr_t old_onipc;	/* X_IPC handler chained to onint()	*/
+-static	long *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
++static	XINT *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
+ static	jmp_buf jmp_save;	/* save IRAF Main jump vector		*/
+ static	jmp_buf jmp_clexit;	/* clexit() jumps here			*/
+ static	int intr_sp;		/* interrupt save stack pointer		*/
+@@ -109,7 +109,7 @@ c_main (
+ 	 * ourselves during normal execution, but when the CL exits we are
+ 	 * not prepared to deal with errors occuring during shutdown.
+ 	 */
+-	XMJBUF (&bp);  jumpcom = (long *)&Memc[bp];
++	XMJBUF (&bp);  jumpcom = (XINT *)&Memc[bp];
+ 	cl_amovi ((int *)jumpcom, (int *)jmp_save, LEN_JUMPBUF);
+ 
+ 	/* Init clexit() in case we have to panic stop.  */
+diff --git a/pkg/ecl/main.c b/pkg/ecl/main.c
+index 56b0681..e0ba05b 100644
+--- a/pkg/ecl/main.c
++++ b/pkg/ecl/main.c
+@@ -63,7 +63,7 @@ int	cldebug = 0;		/* print out lots of goodies if > 0	*/
+ int	cltrace = 0;		/* trace instruction execution if > 0	*/
+ 
+ static	funcptr_t old_onipc;	/* X_IPC handler chained to onint()	*/
+-static	long *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
++static	XINT *jumpcom;		/* IRAF Main setjmp/longjmp buffer	*/
+ static	jmp_buf jmp_save;	/* save IRAF Main jump vector		*/
+ static	jmp_buf jmp_clexit;	/* clexit() jumps here			*/
+ static	int intr_sp;		/* interrupt save stack pointer		*/
+@@ -115,7 +115,7 @@ c_main (
+ 	 * ourselves during normal execution, but when the CL exits we are
+ 	 * not prepared to deal with errors occuring during shutdown.
+ 	 */
+-	XMJBUF (&bp);  jumpcom = (long *)&Memc[bp];
++	XMJBUF (&bp);  jumpcom = (XINT *)&Memc[bp];
+ 	cl_amovi ((int *)jumpcom, (int *)jmp_save, LEN_JUMPBUF);
+ 
+ 	/* Init clexit() in case we have to panic stop.  */


### PR DESCRIPTION
This patch [came from Debian](https://sources.debian.org/src/iraf/2.18.1~rc2-1/debian/patches/Fix-type-of-jumpcon-in-e-cl-main.c.patch/), and fixes the 32-bit build.